### PR TITLE
chore(db): set search_path=public on trigger functions

### DIFF
--- a/supabase/migrations/20250902_set_search_path_triggers.sql
+++ b/supabase/migrations/20250902_set_search_path_triggers.sql
@@ -1,0 +1,3 @@
+-- Ensure trigger functions run with the public schema in scope
+ALTER FUNCTION public.touch_updated_at() SET search_path = public;
+ALTER FUNCTION public.update_updated_at_column() SET search_path = public;


### PR DESCRIPTION
## Summary
- ensure trigger functions run with public schema in scope

## Testing
- no tests were run

------
https://chatgpt.com/codex/tasks/task_e_68b7365d8bbc832a9c2ee3e1481bf309