### PR TITLE
feat: add active location server action

### DIFF
--- a/components/nav/HeaderClient.tsx
+++ b/components/nav/HeaderClient.tsx
@@ -15,6 +15,7 @@ import { UserDropdown } from '@/components/nav/UserDropdown'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { setAppContext } from '@/lib/appContext'
 import { useEffectivePermissions } from '@/hooks/useEffectivePermissions'
+import { setActiveLocationAction } from '@/lib/activeLocation'
 
 // Mock data for demonstration
 const mockOrgs = [
@@ -74,6 +75,7 @@ export default function HeaderClient() {
     }
     router.replace(`?${params.toString()}`)
     await setAppContext(context.org_id ?? undefined, newLoc ?? undefined)
+    await setActiveLocationAction(newLoc ?? undefined)
   }
 
   return (

--- a/lib/activeLocation.ts
+++ b/lib/activeLocation.ts
@@ -1,0 +1,13 @@
+'use server';
+
+import { cookies } from 'next/headers'
+
+export async function setActiveLocationAction(locationId?: string | null) {
+  if (!locationId) {
+    cookies().delete('pn_loc')
+    return
+  }
+
+  cookies().set('pn_loc', locationId, { path: '/', maxAge: 60 * 60 * 24 * 90 })
+}
+


### PR DESCRIPTION
## Summary
- add `use server` directive and cookie helper in `lib/activeLocation`
- call new `setActiveLocationAction` from client header

## Testing
- `npm run lint` *(fails: next not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/picomatch)*
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*


------
https://chatgpt.com/codex/tasks/task_e_68b76073a208832a9fb596b716918234