### PR TITLE
feat: default location at login + robust membership fetch

### DIFF
--- a/components/nav/Header.tsx
+++ b/components/nav/Header.tsx
@@ -3,12 +3,25 @@ import { setActiveLocationAction } from '@/app/actions/active-location';
 import HeaderClient from './HeaderClient';
 
 export default async function Header() {
-  const { active, locations } = await getActiveLocationServer();
-  return (
-    <HeaderClient
-      locations={locations}
-      activeLocationId={active?.id ?? null}
-      setActiveLocation={setActiveLocationAction}
-    />
-  );
+  try {
+    const { active, locations, persisted } = await getActiveLocationServer();
+    return (
+      <HeaderClient
+        locations={locations}
+        activeLocationId={active?.id ?? null}
+        persisted={persisted}
+        setActiveLocation={setActiveLocationAction}
+      />
+    );
+  } catch (err) {
+    console.error('[Header] render fatal', err);
+    return (
+      <HeaderClient
+        locations={[]}
+        activeLocationId={null}
+        persisted={false}
+        setActiveLocation={async () => {}}
+      />
+    );
+  }
 }

--- a/lib/server/activeLocation.ts
+++ b/lib/server/activeLocation.ts
@@ -44,7 +44,7 @@ export async function getUserLocations(): Promise<{ user: { id: string } | null;
 /** Ritorna la location attiva (cookie valido -> by cookie, altrimenti first) + flag se il cookie è già persistito */
 export async function getActiveLocationServer(): Promise<{ active: Loc | null; locations: Loc[]; persisted: boolean }> {
   try {
-    const jar = cookies(); // sync in Server Components
+    const jar = await cookies();
     const cookieId = jar.get('pn_loc')?.value ?? null;
 
     const { user, locations } = await getUserLocations();

--- a/lib/server/activeLocation.ts
+++ b/lib/server/activeLocation.ts
@@ -9,34 +9,54 @@ export async function getUserLocations(): Promise<{ user: { id: string } | null;
     const { data: { user } } = await supabase.auth.getUser();
     if (!user) return { user: null, locations: [] };
 
-    // Tabella corretta + join alla tabella locations
-    const { data, error } = await supabase
+    // 1) membership -> solo IDs (robusto vs RLS/relazioni)
+    const { data: mems, error: e1 } = await supabase
       .from('user_roles_locations')
-      .select('location:locations(id,name)')
+      .select('location_id')
       .eq('user_id', user.id);
 
-    if (error) {
-      console.error('[activeLocation] user_roles_locations query error', error);
+    if (e1) {
+      console.error('[activeLocation] memberships error', e1);
       return { user, locations: [] };
     }
 
-    const locations = (data ?? [])
-      .map((r: any) => r.location)
-      .filter(Boolean) as Loc[];
+    const ids = (mems ?? []).map((m: any) => m.location_id).filter(Boolean);
+    if (ids.length === 0) return { user, locations: [] };
 
-    return { user, locations };
+    // 2) fetch locations per ID
+    const { data: locs, error: e2 } = await supabase
+      .from('locations')
+      .select('id,name')
+      .in('id', ids);
+
+    if (e2) {
+      console.error('[activeLocation] locations error', e2);
+      return { user, locations: [] };
+    }
+
+    return { user, locations: (locs ?? []) as Loc[] };
   } catch (err) {
     console.error('[activeLocation] getUserLocations fatal', err);
     return { user: null, locations: [] };
   }
 }
 
-export async function getActiveLocationServer() {
-  const jar = await cookies();
-  const cookieId = jar.get('pn_loc')?.value ?? null;
-  const { user, locations } = await getUserLocations();
-  if (!user || locations.length === 0) return { active: null, locations };
+/** Ritorna la location attiva (cookie valido -> by cookie, altrimenti first) + flag se il cookie è già persistito */
+export async function getActiveLocationServer(): Promise<{ active: Loc | null; locations: Loc[]; persisted: boolean }> {
+  try {
+    const jar = cookies(); // sync in Server Components
+    const cookieId = jar.get('pn_loc')?.value ?? null;
 
-  const active = locations.find(l => l.id === cookieId) ?? locations[0];
-  return { active, locations };
+    const { user, locations } = await getUserLocations();
+    if (!user || locations.length === 0) return { active: null, locations, persisted: false };
+
+    const byCookie = locations.find(l => l.id === cookieId) ?? null;
+    const active = byCookie ?? locations[0];
+    const persisted = !!byCookie;
+
+    return { active, locations, persisted };
+  } catch (err) {
+    console.error('[activeLocation] getActiveLocationServer fatal', err);
+    return { active: null, locations: [], persisted: false };
+  }
 }


### PR DESCRIPTION
## Summary
- fetch user memberships by ID before querying locations to ensure robustness
- default active location based on cookie or first available, persisting cookie client-side when missing
- hide location switcher when no locations are assigned

## Testing
- `bun run lint` *(fails: next: command not found)*
- `bun run typecheck` *(fails: Cannot find type definition file for 'node')*
- `bun run build` *(fails: next: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b77968b2a8832ab692ec063e66f44f