### PR TITLE
fix(auth): stable SSR session + client permissions bootstrap (+ QA routes)

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -9,6 +9,8 @@ export const metadata: Metadata = {
   description: 'Sistema multi-tenant per la gestione del personale con RBAC e feature flags',
 }
 
+export const dynamic = 'force-dynamic'
+
 export default function AppLayout({
   children,
 }: {

--- a/app/(app)/me/page.tsx
+++ b/app/(app)/me/page.tsx
@@ -30,7 +30,7 @@ async function getUserData(): Promise<{
   roles: UserRole[]
   locations: Array<{ id: string; name: string }>
 }> {
-  const supabase = createSupabaseServerClient()
+  const supabase = await createSupabaseServerClient()
   
   const { data: { user }, error: authError } = await supabase.auth.getUser()
   if (authError || !user) {

--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -10,6 +10,8 @@ import { useAppStore } from '@/lib/store'
 import { useRequireSession } from '@/lib/useRequireSession'
 import { can } from '@/lib/permissions'
 
+export const dynamic = 'force-dynamic'
+
 export default function HomePage() {
   useRequireSession()
   const { context, permissions } = useAppStore()

--- a/app/(app)/qa/whoami/page.tsx
+++ b/app/(app)/qa/whoami/page.tsx
@@ -11,7 +11,7 @@ export default async function QAWhoAmIPage() {
   const currentUserId = await requireAdmin()
   
   // Get current user details
-  const supabase = createSupabaseServerClient()
+  const supabase = await createSupabaseServerClient()
   const { data: { user }, error: authError } = await supabase.auth.getUser()
   
   if (authError || !user) {

--- a/app/actions/active-location.ts
+++ b/app/actions/active-location.ts
@@ -5,7 +5,7 @@ import { revalidatePath } from 'next/cache';
 import { createSupabaseServerClient } from '@/utils/supabase/server';
 
 async function userHasLocation(userId: string, locationId: string) {
-  const supabase = createSupabaseServerClient();
+  const supabase = await createSupabaseServerClient();
   // Tabella corretta: public.user_roles_locations
   // Check di esistenza senza scaricare righe
   const { count, error } = await supabase
@@ -19,7 +19,7 @@ async function userHasLocation(userId: string, locationId: string) {
 }
 
 export async function setActiveLocationAction(locationId?: string | null) {
-  const supabase = createSupabaseServerClient();
+  const supabase = await createSupabaseServerClient();
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) throw new Error('Unauthorized');
 

--- a/app/api/qa/cookies/route.ts
+++ b/app/api/qa/cookies/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const jar = await cookies();
+  const names = jar.getAll().map(c => c.name);
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL || '';
+  let projectRef = '';
+  try {
+    projectRef = new URL(url).hostname.split('.')[0];
+  } catch {
+    projectRef = '';
+  }
+  const prefix = `sb-${projectRef}-auth-token`;
+  const hasAuthCookie = names.some(n => n.startsWith(prefix));
+  return NextResponse.json({ cookieNames: names, projectRef, hasAuthCookie });
+}

--- a/app/api/qa/session/route.ts
+++ b/app/api/qa/session/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server';
+import { createSupabaseServerClient } from '@/utils/supabase/server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const supabase = await createSupabaseServerClient();
+  const { data: { user }, error } = await supabase.auth.getUser();
+  return NextResponse.json({
+    email: user?.email ?? null,
+    userId: user?.id ?? null,
+    error: error?.message ?? null,
+  });
+}

--- a/app/api/qa/snapshot/route.ts
+++ b/app/api/qa/snapshot/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server';
+import { createSupabaseServerClient } from '@/utils/supabase/server';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const supabase = await createSupabaseServerClient();
+  const { data, error } = await supabase.rpc('app_get_auth_snapshot');
+  return NextResponse.json({ data, error: error?.message ?? null });
+}

--- a/components/nav/Header.tsx
+++ b/components/nav/Header.tsx
@@ -2,6 +2,8 @@ import { getActiveLocationServer } from '@/lib/server/activeLocation';
 import { setActiveLocationAction } from '@/app/actions/active-location';
 import HeaderClient from './HeaderClient';
 
+export const dynamic = 'force-dynamic';
+
 export default async function Header() {
   const { active, locations, persisted, meta } = await getActiveLocationServer();
 

--- a/components/nav/HeaderClient.tsx
+++ b/components/nav/HeaderClient.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useRef, useTransition } from 'react';
 import { useRouter } from 'next/navigation';
 import { UserDropdown } from '@/components/nav/UserDropdown';
+import { useAppStore } from '@/lib/store';
+import { useEffectivePermissions } from '@/hooks/useEffectivePermissions';
 
 export default function HeaderClient({
   locations,
@@ -20,6 +22,18 @@ export default function HeaderClient({
   const router = useRouter();
   const [, startTransition] = useTransition();
   const didPersistRef = useRef(false);
+  const setContext = useAppStore(state => state.setContext);
+  useEffectivePermissions();
+
+  useEffect(() => {
+    const active = locations.find(l => l.id === activeLocationId) || null;
+    const prev = useAppStore.getState().context;
+    setContext({
+      ...prev,
+      location_id: active?.id ?? null,
+      location_name: active?.name ?? null,
+    });
+  }, [locations, activeLocationId, setContext]);
 
   // Auto-persist della default location quando il server ha scelto ma il cookie non c'è
   useEffect(() => {

--- a/hooks/useEffectivePermissions.ts
+++ b/hooks/useEffectivePermissions.ts
@@ -9,7 +9,7 @@ export function useEffectivePermissions() {
 
   useEffect(() => {
     async function load() {
-      const perms = await getUserPermissions(undefined, context.location_id || undefined)
+      const perms = await getUserPermissions(context.location_id || undefined)
       setPermissions(perms)
     }
     if (context.location_id) {

--- a/lib/admin/guards.ts
+++ b/lib/admin/guards.ts
@@ -8,7 +8,7 @@ import { canAny } from '@/lib/permissions/can'
  */
 export async function requireAdmin(): Promise<string> {
   try {
-    const supabase = createSupabaseServerClient()
+    const supabase = await createSupabaseServerClient()
     const { data: { user }, error: authError } = await supabase.auth.getUser()
 
     if (authError || !user) {
@@ -38,7 +38,7 @@ export async function requireAdmin(): Promise<string> {
  */
 export async function checkAdminAccess(): Promise<{ userId: string | null; hasAccess: boolean }> {
   try {
-    const supabase = createSupabaseServerClient()
+    const supabase = await createSupabaseServerClient()
     const { data: { user }, error: authError } = await supabase.auth.getUser()
 
     if (authError || !user) {

--- a/lib/data/admin.ts
+++ b/lib/data/admin.ts
@@ -68,7 +68,7 @@ export interface UserPermissionOverride {
  */
 export async function checkIsAdmin(): Promise<boolean> {
   try {
-    const supabase = createSupabaseServerClient()
+    const supabase = await createSupabaseServerClient()
     
     const { data: { user }, error: authError } = await supabase.auth.getUser()
     if (authError || !user) {
@@ -109,7 +109,7 @@ export async function getUsersWithDetails(
   search: string = ''
 ): Promise<{ users: UserWithDetails[]; total: number; hasMore: boolean }> {
   try {
-    const supabase = createSupabaseServerClient()
+    const supabase = await createSupabaseServerClient()
     
     // Verifica autorizzazioni admin
     const isAdmin = await checkIsAdmin()
@@ -173,7 +173,7 @@ export async function getUsersWithDetails(
  */
 export async function getUserById(userId: string): Promise<UserWithDetails | null> {
   try {
-    const supabase = createSupabaseServerClient()
+    const supabase = await createSupabaseServerClient()
     
     // Verifica autorizzazioni admin
     const isAdmin = await checkIsAdmin()
@@ -217,7 +217,7 @@ export async function getUserById(userId: string): Promise<UserWithDetails | nul
  */
 export async function getUserRolesByLocation(userId: string): Promise<UserRolesByLocation[]> {
   try {
-    const supabase = createSupabaseServerClient()
+    const supabase = await createSupabaseServerClient()
     
     // Verifica autorizzazioni admin
     const isAdmin = await checkIsAdmin()
@@ -270,7 +270,7 @@ export async function getUserRolesByLocation(userId: string): Promise<UserRolesB
  */
 export async function getUserPermissionOverrides(userId: string): Promise<UserPermissionOverride[]> {
   try {
-    const supabase = createSupabaseServerClient()
+    const supabase = await createSupabaseServerClient()
     
     // Verifica autorizzazioni admin
     const isAdmin = await checkIsAdmin()

--- a/lib/permissions.ts
+++ b/lib/permissions.ts
@@ -18,9 +18,8 @@ export function can(perms: PermBag, required: PermReq): boolean {
   return reqs.every(r => bag.has(r));
 }
 
-export async function getUserPermissions(orgId?: string, locationId?: string): Promise<Permission[]> {
+export async function getUserPermissions(locationId?: string): Promise<Permission[]> {
   const qs = new URLSearchParams();
-  if (orgId) qs.set('orgId', orgId);
   if (locationId) qs.set('locationId', locationId);
   const res = await fetch(`/api/v1/me/permissions?${qs.toString()}`, { credentials: 'include' });
   if (!res.ok) return [];

--- a/lib/server/activeLocation.ts
+++ b/lib/server/activeLocation.ts
@@ -6,7 +6,7 @@ type Meta = { error?: string };
 
 export async function getUserLocations(): Promise<{ user: { id: string } | null; locations: Loc[]; meta: Meta }> {
   try {
-    const supabase = createSupabaseServerClient();
+    const supabase = await createSupabaseServerClient();
     const { data: { user } } = await supabase.auth.getUser();
     if (!user) return { user: null, locations: [], meta: {} };
 

--- a/utils/supabase/middleware.ts
+++ b/utils/supabase/middleware.ts
@@ -1,12 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createServerClient, type CookieOptions } from '@supabase/ssr';
+import { requireSupabaseEnv } from './config';
 
 export async function middleware(req: NextRequest) {
   const res = NextResponse.next();
 
+  const { url, anon } = requireSupabaseEnv();
   const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    url,
+    anon,
     {
       cookies: {
         get: (name: string) => req.cookies.get(name)?.value,

--- a/utils/supabase/server.ts
+++ b/utils/supabase/server.ts
@@ -7,13 +7,17 @@ export async function createSupabaseServerClient() {
   const cookieStore = await cookies();
 
   return createServerClient(url, anon, {
-    cookies: {
-      get: (name: string) => cookieStore.get(name)?.value,
-      set: (name: string, value: string, options: CookieOptions) =>
-        cookieStore.set({ name, value, ...options }),
-      remove: (name: string, options: CookieOptions) =>
-        cookieStore.set({ name, value: '', ...options, maxAge: 0 }),
-    },
+    cookies: () => ({
+      get(name: string) {
+        return cookieStore.get(name)?.value;
+      },
+      set(name: string, value: string, options?: CookieOptions) {
+        cookieStore.set(name, value, options);
+      },
+      remove(name: string, options?: CookieOptions) {
+        cookieStore.set(name, '', { ...(options ?? {}), maxAge: 0 });
+      },
+    }),
   });
 }
 

--- a/utils/supabase/server.ts
+++ b/utils/supabase/server.ts
@@ -2,9 +2,9 @@ import { cookies } from 'next/headers';
 import { createServerClient, type CookieOptions } from '@supabase/ssr';
 import { requireSupabaseEnv } from './config';
 
-export function createSupabaseServerClient() {
+export async function createSupabaseServerClient() {
   const { url, anon } = requireSupabaseEnv();
-  const cookieStore = cookies() as any;
+  const cookieStore = await cookies();
 
   return createServerClient(url, anon, {
     cookies: {


### PR DESCRIPTION
## Summary
- update Supabase SSR client to Next 15 API and enforce env vars
- bootstrap client context and permissions in header; add QA diagnostics routes
- implement robust permissions endpoint backed by service role

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*
- `npm run test:smoke` *(fails: tsx: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb7cfb1368832a8568135cac2e9d1b