### PR TITLE
feat: normalize and unify permissions

### DIFF
--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -62,21 +62,21 @@ export default function HomePage() {
       description: 'Amministra utenti e permessi',
       href: '/admin/users',
       icon: Users,
-        permission: 'locations.manage_users'
+      permission: 'users:manage'
     },
     {
       title: 'Feature Flags',
       description: 'Configura funzionalità per moduli',
       href: '/admin/feature-flags',
       icon: Flag,
-        permission: 'locations.manage_flags'
+      permission: 'flags:view'
     },
     {
       title: 'Impostazioni',
       description: 'Configurazioni generali',
       href: '/settings',
       icon: Settings,
-        permission: 'locations.view'
+      permission: '*'
     }
   ]
 

--- a/app/(app)/qa/page.tsx
+++ b/app/(app)/qa/page.tsx
@@ -1,0 +1,17 @@
+import Link from 'next/link'
+import { requireAdmin } from '@/lib/admin/guards'
+
+export const dynamic = 'force-dynamic'
+
+export default async function QAIndexPage() {
+  await requireAdmin()
+  return (
+    <div className="container mx-auto py-8 space-y-4">
+      <h1 className="text-3xl font-bold">QA Tools</h1>
+      <ul className="list-disc pl-4 space-y-2">
+        <li><Link href="/qa/whoami">Who Am I</Link></li>
+        <li><Link href="/qa/health">Health Check</Link></li>
+      </ul>
+    </div>
+  )
+}

--- a/components/nav/SidebarClient.tsx
+++ b/components/nav/SidebarClient.tsx
@@ -10,7 +10,6 @@ import {
   Home,
   Users,
   Bug,
-  Package,
   Settings,
   ChevronLeft,
   ChevronRight,
@@ -20,10 +19,9 @@ import { can } from '@/lib/permissions'
 
 const navigation: { name: string; href: string; icon: any; permission: string | null }[] = [
   { name: 'Dashboard', href: '/', icon: Home, permission: null },
-  { name: 'Amministrazione', href: '/admin/users', icon: Users, permission: 'locations.manage_users' },
-  { name: 'QA & Debug', href: '/qa', icon: Bug, permission: 'manage_users' },
-  { name: 'Moduli', href: '/modules', icon: Package, permission: 'modules.view' },
-  { name: 'Impostazioni', href: '/settings', icon: Settings, permission: 'locations.view' },
+  { name: 'Amministrazione', href: '/admin/users', icon: Users, permission: 'users:manage' },
+  { name: 'QA & Debug', href: '/qa', icon: Bug, permission: '*' },
+  { name: 'Impostazioni', href: '/settings', icon: Settings, permission: null },
 ]
 
 export default function SidebarClient() {

--- a/lib/permissions.ts
+++ b/lib/permissions.ts
@@ -6,16 +6,54 @@ export type AnyPermission = string;
 export type PermBag = ReadonlyArray<AnyPermission> | Set<AnyPermission>;
 export type PermReq = AnyPermission | ReadonlyArray<AnyPermission>;
 
+const synonymMap: Record<string, string> = {
+  'manage:users': 'users:manage',
+  'view:users': 'users:view',
+  'assign:roles': 'users:manage',
+  'invite:users': 'users:invite',
+  'flags:view': 'flags:view',
+  'locations:view': 'locations:view',
+  'manage:inventory': 'inventory:manage',
+  'view:inventory': 'inventory:view',
+  'manage:orders': 'orders:manage',
+  'view:orders': 'orders:view',
+  'manage:haccp': 'haccp:manage',
+  'view:haccp': 'haccp:view',
+  'manage:maintenance': 'maintenance:manage',
+  'view:maintenance': 'maintenance:view',
+  'manage:financial': 'financial:manage',
+  'view:financial': 'financial:view',
+  'manage:settings': 'settings:manage',
+  'view:settings': 'settings:view',
+};
+
+/** Normalizza il nome di un permesso */
+export function normalizePermission(p: string): string {
+  const colonized = p.toLowerCase().replace(/[._]/g, ':');
+  return synonymMap[colonized] ?? colonized;
+}
+
+/** Normalizza e deduplica una lista di permessi */
+export function normalizeSet(list: string[]): string[] {
+  return Array.from(new Set(list.map(normalizePermission)));
+}
+
 /** Normalizza un contenitore di permessi in Set<string> */
 export function toPermSet(perms: PermBag): Set<AnyPermission> {
-  return perms instanceof Set ? perms : new Set(perms);
+  const arr = perms instanceof Set ? Array.from(perms) : perms;
+  return new Set(normalizeSet(arr as string[]));
 }
 
 /** Ritorna true se TUTTI i permessi richiesti sono presenti */
 export function can(perms: PermBag, required: PermReq): boolean {
   const bag = toPermSet(perms);
+  if (bag.has('*')) return true;
   const reqs = Array.isArray(required) ? required : [required];
-  return reqs.every(r => bag.has(r));
+  return reqs.map(normalizePermission).every(r => {
+    if (bag.has(r)) return true;
+    const module = r.split(':')[0];
+    return bag.has(`${module}:*`);
+  });
 }
 
 export async function getUserPermissions(locationId?: string): Promise<Permission[]> {
@@ -24,5 +62,6 @@ export async function getUserPermissions(locationId?: string): Promise<Permissio
   const res = await fetch(`/api/v1/me/permissions?${qs.toString()}`, { credentials: 'include' });
   if (!res.ok) return [];
   const json = await res.json();
-  return Array.isArray(json?.permissions) ? (json.permissions as Permission[]) : [];
+  const perms = Array.isArray(json?.permissions) ? (json.permissions as Permission[]) : [];
+  return normalizeSet(perms);
 }

--- a/lib/permissions/permissions.test.ts
+++ b/lib/permissions/permissions.test.ts
@@ -1,15 +1,20 @@
-import { can } from '../permissions';
+import { can, normalizePermission } from '../permissions';
+
+describe('normalizePermission', () => {
+  test('maps legacy names', () => {
+    expect(normalizePermission('manage_users')).toBe('users:manage');
+    expect(normalizePermission('Flags.View')).toBe('flags:view');
+  });
+});
 
 describe('can', () => {
-  test('exact permission', () => {
+  test('exact and wildcard permissions', () => {
     expect(can(['orders:view'], 'orders:view')).toBe(true);
-  });
-
-  test('wildcard permission', () => {
+    expect(can(['orders:*'], 'orders:view')).toBe(true);
     expect(can(['*'], 'orders:view')).toBe(true);
   });
 
-  test('module wildcard', () => {
-    expect(can(['orders:*'], 'orders:view')).toBe(true);
+  test('normalizes inputs', () => {
+    expect(can(['users:manage'], 'manage_users')).toBe(true);
   });
 });

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
+import { can } from './permissions'
 
 interface AppContext {
   org_id: string | null
@@ -35,7 +36,7 @@ export const useAppStore = create<AppState>()(
       }),
       hasPermission: (permission) => {
         const { permissions } = get()
-        return permissions.includes(permission)
+        return can(permissions, permission)
       },
     }),
     {


### PR DESCRIPTION
## Summary
- normalize permission names and add admin wildcard
- load global and location permissions on client
- tighten sidebar/dashboard gating and add QA index

## Testing
- `bun test`
- `npm run lint` *(fails: next: not found)*
- `npm run test:smoke` *(fails: tsx: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb943b7388832a8c28f79545c00c60