### PR TITLE
chore(env): standardize Supabase service role var to SUPABASE_SERVICE_ROLE_KEY and enforce node runtime for server handlers

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server'
+import { getSupabaseServiceRoleKey } from '@/lib/env'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -15,10 +16,17 @@ export async function GET() {
     }
 
     // Supabase configuration check
+    let serviceRolePresent = true
+    try {
+      getSupabaseServiceRoleKey()
+    } catch {
+      serviceRolePresent = false
+    }
+
     const supabase = {
       url: process.env.NEXT_PUBLIC_SUPABASE_URL || 'not_set',
       anon_key_present: !!process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-      service_role_present: !!process.env.SUPABASE_SERVICE_ROLE_KEY
+      service_role_present: serviceRolePresent
     }
 
     // Environment variables check (NEXT_PUBLIC_* only, for security)

--- a/app/api/internal/setup/bootstrap-report/route.ts
+++ b/app/api/internal/setup/bootstrap-report/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { getSupabaseServiceRoleKey } from '@/lib/env'
 
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
@@ -26,6 +27,11 @@ export async function GET(request: NextRequest) {
     console.log('📊 Generating Bootstrap Implementation Report...')
 
     // Environment Status
+    let serviceRoleKey: string | undefined
+    try {
+      serviceRoleKey = getSupabaseServiceRoleKey()
+    } catch {}
+
     const envStatus = {
       supabase_url: {
         configured: !!process.env.NEXT_PUBLIC_SUPABASE_URL,
@@ -40,10 +46,10 @@ export async function GET(request: NextRequest) {
           : 'NOT SET'
       },
       supabase_service_role_key: {
-        configured: !!process.env.SUPABASE_SERVICE_ROLE_KEY,
-        format_valid: process.env.SUPABASE_SERVICE_ROLE_KEY?.startsWith('eyJ') || false,
-        masked: process.env.SUPABASE_SERVICE_ROLE_KEY 
-          ? `${process.env.SUPABASE_SERVICE_ROLE_KEY.substring(0, 20)}...`
+        configured: !!serviceRoleKey,
+        format_valid: serviceRoleKey?.startsWith('eyJ') || false,
+        masked: serviceRoleKey
+          ? `${serviceRoleKey.substring(0, 20)}...`
           : 'NOT SET'
       },
       resend_api_key: {

--- a/app/api/v1/admin/bootstrap/route.ts
+++ b/app/api/v1/admin/bootstrap/route.ts
@@ -1,4 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { admin } from '@/lib/supabase/service';
+import { getSupabaseServiceRoleKey } from '@/lib/env';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -11,10 +13,6 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ ok: false, error: 'unauthorized' }, { status: 401 });
     }
 
-    if (!process.env.SUPABASE_SERVICE_ROLE_KEY) {
-      return NextResponse.json({ ok: false, error: 'service_role_not_configured' }, { status: 503 });
-    }
-
     const dbUrl = process.env.DATABASE_URL || process.env.SUPABASE_DB_URL;
     if (!dbUrl) {
       return NextResponse.json({ ok: false, error: 'db_not_configured' }, { status: 503 });
@@ -22,8 +20,8 @@ export async function POST(req: NextRequest) {
 
     let supabase;
     try {
-      const { createSupabaseAdminClient } = await import('@/lib/supabase/server');
-      supabase = createSupabaseAdminClient();
+      getSupabaseServiceRoleKey();
+      supabase = admin;
     } catch {
       return NextResponse.json({ ok: false, error: 'service_role_not_configured' }, { status: 503 });
     }

--- a/app/api/v1/admin/invitations/route.ts
+++ b/app/api/v1/admin/invitations/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/utils/supabase/server'
-import { createSupabaseAdminClient } from '@/lib/supabase/server'
+import { admin } from '@/lib/supabase/service'
+import { getSupabaseServiceRoleKey } from '@/lib/env'
 import { z } from 'zod'
 import { randomBytes } from 'crypto'
 
@@ -29,7 +30,7 @@ export async function GET() {
     }
 
     // Check if user can manage users
-    const supabaseAdmin = createSupabaseAdminClient()
+    const supabaseAdmin = admin
     const { data: isAdmin } = await supabaseAdmin.rpc('user_is_admin', { p_user: user.id })
     
     if (!isAdmin) {
@@ -85,7 +86,7 @@ export async function POST(request: Request) {
     }
 
     // Check permissions
-    const supabaseAdmin = createSupabaseAdminClient()
+    const supabaseAdmin = admin
     const { data: isAdmin } = await supabaseAdmin.rpc('user_is_admin', { p_user: user.id })
     
     if (!isAdmin) {
@@ -180,7 +181,7 @@ export async function POST(request: Request) {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': `Bearer ${process.env.SUPABASE_SERVICE_ROLE_KEY}`,
+          'Authorization': `Bearer ${getSupabaseServiceRoleKey()}`,
         },
         body: JSON.stringify(emailPayload),
       })

--- a/app/api/v1/admin/locations/route.ts
+++ b/app/api/v1/admin/locations/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server"
-import { createSupabaseAdminClient } from "@/lib/supabase/server"
+import { admin } from "@/lib/supabase/service"
 import { checkAdminAccess } from "@/lib/admin/guards"
 
 export const dynamic = 'force-dynamic'
@@ -14,7 +14,7 @@ export async function GET() {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 403 })
     }
 
-    const supabaseAdmin = createSupabaseAdminClient()
+    const supabaseAdmin = admin
 
     // Fetch all active locations
     const { data: locations, error } = await supabaseAdmin

--- a/app/api/v1/admin/permissions/route.ts
+++ b/app/api/v1/admin/permissions/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server"
-import { createSupabaseAdminClient } from "@/lib/supabase/server"
+import { admin } from "@/lib/supabase/service"
 import { checkAdminAccess } from "@/lib/admin/guards"
 
 export const dynamic = 'force-dynamic'
@@ -14,7 +14,7 @@ export async function GET() {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 403 })
     }
 
-    const supabaseAdmin = createSupabaseAdminClient()
+    const supabaseAdmin = admin
 
     // Fetch all permissions
     const { data: permissions, error } = await supabaseAdmin

--- a/app/api/v1/admin/roles/route.ts
+++ b/app/api/v1/admin/roles/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server"
-import { createSupabaseAdminClient } from "@/lib/supabase/server"
+import { admin } from "@/lib/supabase/service"
 import { checkAdminAccess } from "@/lib/admin/guards"
 
 export const dynamic = 'force-dynamic'
@@ -14,7 +14,7 @@ export async function GET() {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 403 })
     }
 
-    const supabaseAdmin = createSupabaseAdminClient()
+    const supabaseAdmin = admin
 
     // Fetch all active roles
     const { data: roles, error } = await supabaseAdmin

--- a/app/api/v1/admin/users/[userId]/permissions/route.ts
+++ b/app/api/v1/admin/users/[userId]/permissions/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/utils/supabase/server'
-import { createSupabaseAdminClient } from '@/lib/supabase/server'
+import { admin } from '@/lib/supabase/service'
 import { normalizeSet } from '@/lib/permissions'
 
 export const runtime = 'nodejs'
@@ -15,7 +15,7 @@ export async function GET(request: Request, { params }: { params: { userId: stri
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
-    const supabaseAdmin = createSupabaseAdminClient()
+    const supabaseAdmin = admin
     
     // Check if current user can view user permissions
     const { data: isAdmin } = await supabaseAdmin.rpc('user_is_admin', { p_user: user.id })

--- a/app/api/v1/admin/users/[userId]/roles/route.ts
+++ b/app/api/v1/admin/users/[userId]/roles/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server"
 import { createSupabaseServerClient } from "@/utils/supabase/server"
-import { createSupabaseAdminClient } from "@/lib/supabase/server"
+import { admin } from "@/lib/supabase/service"
 import { checkAdminAccess } from "@/lib/admin/guards"
 
 export const dynamic = 'force-dynamic'
@@ -40,7 +40,7 @@ export async function POST(
       return NextResponse.json({ error: 'Unauthorized' }, { status: 403 })
     }
 
-    const supabaseAdmin = createSupabaseAdminClient()
+    const supabaseAdmin = admin
     const { userId } = params
     const body: AssignRoleRequest = await req.json()
 
@@ -186,7 +186,7 @@ export async function DELETE(
       return NextResponse.json({ error: 'Unauthorized' }, { status: 403 })
     }
 
-    const supabaseAdmin = createSupabaseAdminClient()
+    const supabaseAdmin = admin
     const { userId } = params
     const body: RevokeRoleRequest = await req.json()
 

--- a/app/api/v1/me/permissions/route.ts
+++ b/app/api/v1/me/permissions/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { createSupabaseServerClient } from '@/utils/supabase/server';
-import { createSupabaseAdminClient } from '@/lib/supabase/server';
+import { admin } from '@/lib/supabase/service';
 import { normalizeSet } from '@/lib/permissions';
 
 export const runtime = 'nodejs';
@@ -18,7 +18,7 @@ export async function GET(req: Request) {
       return NextResponse.json({ permissions: [] }, { status: 401 });
     }
 
-    const supabaseAdmin = createSupabaseAdminClient();
+    const supabaseAdmin = admin;
 
     let assignmentsQuery = supabaseAdmin
       .from('user_roles_locations')

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,0 +1,17 @@
+import 'server-only';
+
+function req(name: string): string {
+  const v = process.env[name];
+  if (!v) throw new Error(`Missing required env: ${name}`);
+  return v;
+}
+
+export function getSupabaseUrl() {
+  return req('NEXT_PUBLIC_SUPABASE_URL');
+}
+export function getSupabaseAnonKey() {
+  return req('NEXT_PUBLIC_SUPABASE_ANON_KEY');
+}
+export function getSupabaseServiceRoleKey() {
+  return req('SUPABASE_SERVICE_ROLE_KEY');
+}

--- a/lib/permissions/can.ts
+++ b/lib/permissions/can.ts
@@ -20,8 +20,7 @@ export async function can(
     // Server-side check (when running in Node.js environment)
     if (typeof window === 'undefined') {
       // Import server utilities only on server-side
-      const { createSupabaseAdminClient } = await import('@/lib/supabase/server')
-      const supabaseAdmin = createSupabaseAdminClient()
+      const { admin: supabaseAdmin } = await import('@/lib/supabase/service')
 
       // Use the existing get_effective_permissions function if available
       try {

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,30 +1,7 @@
-import { createClient, type SupabaseClient } from '@supabase/supabase-js';
-import { requireSupabaseEnv } from '@/utils/supabase/config';
-
-function initAdminClient(): SupabaseClient {
-  const { url } = requireSupabaseEnv();
-  const serviceRole = process.env.SUPABASE_SERVICE_ROLE_KEY;
-  if (!serviceRole) {
-    throw new Error('Supabase env missing: set SUPABASE_SERVICE_ROLE_KEY');
-  }
-  return createClient(url, serviceRole, {
-    auth: {
-      autoRefreshToken: false,
-      persistSession: false,
-    },
-  });
-}
+import { admin } from './service';
 
 export function createSupabaseAdminClient() {
-  return initAdminClient();
+  return admin;
 }
 
-let cached: SupabaseClient | null = null;
-export const supabaseAdmin = new Proxy({} as SupabaseClient, {
-  get(_target, prop) {
-    if (!cached) cached = initAdminClient();
-    // @ts-ignore
-    return cached[prop];
-  },
-});
-
+export const supabaseAdmin = admin;

--- a/lib/supabase/service.ts
+++ b/lib/supabase/service.ts
@@ -1,0 +1,10 @@
+import 'server-only';
+export const runtime = 'nodejs';
+import { createClient } from '@supabase/supabase-js';
+import { getSupabaseUrl, getSupabaseServiceRoleKey } from '@/lib/env';
+
+export const admin = createClient(
+  getSupabaseUrl(),
+  getSupabaseServiceRoleKey(),
+  { auth: { autoRefreshToken: false, persistSession: false } }
+);

--- a/scripts/get-supabase-keys.js
+++ b/scripts/get-supabase-keys.js
@@ -13,8 +13,7 @@ const envVars = [
   'NEXT_PUBLIC_SUPABASE_URL', 
   'SUPABASE_ANON_KEY',
   'NEXT_PUBLIC_SUPABASE_ANON_KEY',
-  'SUPABASE_SERVICE_ROLE_KEY',
-  'SUPABASE_SERVICE_KEY'
+  'SUPABASE_SERVICE_ROLE_KEY'
 ]
 
 console.log('📋 Environment Variables:')
@@ -34,7 +33,7 @@ envVars.forEach(varName => {
 console.log('\n🎯 Expected Configuration:')
 console.log('   SUPABASE_URL: https://gsgqcsaycyjkbeepwoto.supabase.co')
 console.log('   ANON_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9... (starts with eyJ)')
-console.log('   SERVICE_ROLE_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9... (starts with eyJ)')
+console.log('   SUPABASE_SERVICE_ROLE_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9... (starts with eyJ)')
 
 console.log('\n💡 Next Steps:')
 console.log('   1. Get keys from Supabase Dashboard > Settings > API')

--- a/scripts/test-all.ts
+++ b/scripts/test-all.ts
@@ -1,6 +1,7 @@
 import { runSmokeTests } from '../tests/smoke'
 import { runRLSPermissionTests } from '../tests/rls-permissions'
-import { supabaseAdmin } from '../lib/supabase/server'
+import { admin as supabaseAdmin } from '../lib/supabase/service'
+import { getSupabaseServiceRoleKey } from '../lib/env'
 
 async function generateReport() {
   console.log('📋 Generating comprehensive test report...\n')
@@ -9,7 +10,14 @@ async function generateReport() {
   console.log('🔧 Environment Configuration:')
   console.log(`   SUPABASE_URL: ${process.env.SUPABASE_URL ? '✓ Set' : '❌ Missing'}`)
   console.log(`   SUPABASE_ANON_KEY: ${process.env.SUPABASE_ANON_KEY ? `✓ Set (last 4: ...${process.env.SUPABASE_ANON_KEY.slice(-4)})` : '❌ Missing'}`)
-  console.log(`   SUPABASE_SERVICE_ROLE_KEY: ${process.env.SUPABASE_SERVICE_ROLE_KEY ? `✓ Set (last 4: ...${process.env.SUPABASE_SERVICE_ROLE_KEY.slice(-4)})` : '❌ Missing'}`)
+  let serviceRoleInfo
+  try {
+    const key = getSupabaseServiceRoleKey()
+    serviceRoleInfo = `✓ Set (last 4: ...${key.slice(-4)})`
+  } catch {
+    serviceRoleInfo = '❌ Missing'
+  }
+  console.log(`   SUPABASE_SERVICE_ROLE_KEY: ${serviceRoleInfo}`)
   console.log(`   RESEND_API_KEY: ${process.env.RESEND_API_KEY ? `✓ Set (last 4: ...${process.env.RESEND_API_KEY.slice(-4)})` : '❌ Missing'}`)
   console.log('')
   

--- a/scripts/test-mock.ts
+++ b/scripts/test-mock.ts
@@ -3,6 +3,8 @@
  * Runs without requiring actual Supabase credentials
  */
 
+import { getSupabaseServiceRoleKey } from '../lib/env'
+
 async function mockDatabaseConnectivity() {
   console.log('🔌 Testing database connectivity...')
   console.log('   ✅ Database connection successful (mocked)')
@@ -134,7 +136,14 @@ async function generateSystemReport() {
   console.log('🔧 Environment Configuration:')
   console.log(`   SUPABASE_URL: ${process.env.NEXT_PUBLIC_SUPABASE_URL ? '✓ Set' : '❌ Missing (use .env.example)'}`)
   console.log(`   SUPABASE_ANON_KEY: ${process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ? `✓ Set (last 4: ...${process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY.slice(-4)})` : '❌ Missing (use .env.example)'}`)
-  console.log(`   SUPABASE_SERVICE_ROLE_KEY: ${process.env.SUPABASE_SERVICE_ROLE_KEY ? `✓ Set (last 4: ...${process.env.SUPABASE_SERVICE_ROLE_KEY.slice(-4)})` : '❌ Missing (use .env.example)'}`)
+  let serviceRoleInfo
+  try {
+    const key = getSupabaseServiceRoleKey()
+    serviceRoleInfo = `✓ Set (last 4: ...${key.slice(-4)})`
+  } catch {
+    serviceRoleInfo = '❌ Missing (use .env.example)'
+  }
+  console.log(`   SUPABASE_SERVICE_ROLE_KEY: ${serviceRoleInfo}`)
   console.log(`   RESEND_API_KEY: ${process.env.RESEND_API_KEY ? `✓ Set (last 4: ...${process.env.RESEND_API_KEY.slice(-4)})` : '❌ Missing (use .env.example)'}`)
   console.log('')
   

--- a/scripts/test-prompt0.ts
+++ b/scripts/test-prompt0.ts
@@ -1,6 +1,7 @@
 import { runBootstrapTests } from '../tests/bootstrap-tests'
 import { runStorageTests } from '../tests/storage-tests'
 import { Resend } from 'resend'
+import { getSupabaseServiceRoleKey } from '../lib/env'
 
 type TestResults = {
   bootstrap: boolean
@@ -38,7 +39,14 @@ async function generateSystemReport() {
   console.log('🔧 Environment Configuration:')
   console.log(`   SUPABASE_URL: ${process.env.SUPABASE_URL ? '✓ Set' : '❌ Missing'}`)
   console.log(`   SUPABASE_ANON_KEY: ${process.env.SUPABASE_ANON_KEY ? `✓ Set (last 4: ...${process.env.SUPABASE_ANON_KEY.slice(-4)})` : '❌ Missing'}`)
-  console.log(`   SUPABASE_SERVICE_ROLE_KEY: ${process.env.SUPABASE_SERVICE_ROLE_KEY ? `✓ Set (last 4: ...${process.env.SUPABASE_SERVICE_ROLE_KEY.slice(-4)})` : '❌ Missing'}`)
+  let serviceRoleInfo
+  try {
+    const key = getSupabaseServiceRoleKey()
+    serviceRoleInfo = `✓ Set (last 4: ...${key.slice(-4)})`
+  } catch {
+    serviceRoleInfo = '❌ Missing'
+  }
+  console.log(`   SUPABASE_SERVICE_ROLE_KEY: ${serviceRoleInfo}`)
   console.log(`   RESEND_API_KEY: ${process.env.RESEND_API_KEY ? `✓ Set (last 4: ...${process.env.RESEND_API_KEY.slice(-4)})` : '❌ Missing'}`)
   console.log('')
   


### PR DESCRIPTION
## Summary
- add `lib/env.ts` to centralize Supabase env access
- introduce `lib/supabase/service.ts` admin client and use it across server routes and scripts
- ensure server handlers use Node runtime and updated service role key loading

## Testing
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*
- `npm run build` *(fails: next not found)*
- `npx tsx app/api/v1/me/permissions/route.ts` *(fails: 403 Forbidden fetching tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68bba3bb4580832aa266599ebdaf777e