### PR TITLE
Fix SSR admin guards to honor wildcard and canonical permissions

### DIFF
--- a/app/(app)/admin/users/[id]/page.tsx
+++ b/app/(app)/admin/users/[id]/page.tsx
@@ -15,6 +15,8 @@ import { getUserById, getUserRolesByLocation, getUserPermissionOverrides } from 
 import { requireAdmin } from '@/lib/admin/guards'
 import { UserDetailSkeleton } from '@/components/ui/loading-skeleton'
 
+export const runtime = 'nodejs';
+
 interface Props {
   params: {
     id: string

--- a/app/(app)/admin/users/invite/page.tsx
+++ b/app/(app)/admin/users/invite/page.tsx
@@ -7,6 +7,8 @@ import Link from 'next/link'
 import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
 
+export const runtime = 'nodejs';
+
 export default async function InviteUserPage() {
   await requireAdmin()
 

--- a/app/(app)/admin/users/page.tsx
+++ b/app/(app)/admin/users/page.tsx
@@ -9,6 +9,8 @@ import { getUsersWithDetails } from '@/lib/data/admin'
 import { requireAdmin } from '@/lib/admin/guards'
 import { TableSkeleton } from '@/components/ui/loading-skeleton'
 
+export const runtime = 'nodejs';
+
 interface SearchParams {
   page?: string
   search?: string

--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -62,7 +62,7 @@ export default function HomePage() {
       description: 'Amministra utenti e permessi',
       href: '/admin/users',
       icon: Users,
-      permission: 'manage_users'
+      permission: 'users:manage'
     },
     {
       title: 'Feature Flags',

--- a/app/(app)/qa/health/page.tsx
+++ b/app/(app)/qa/health/page.tsx
@@ -4,6 +4,7 @@ import { Badge } from '@/components/ui/badge'
 import { Activity, Server, Eye, EyeOff, CheckCircle, XCircle } from 'lucide-react'
 import { requireAdmin } from '@/lib/admin/guards'
 
+export const runtime = 'nodejs';
 interface HealthCheckResult {
   status: string
   timestamp: string

--- a/app/(app)/qa/page.tsx
+++ b/app/(app)/qa/page.tsx
@@ -15,6 +15,8 @@ import {
   AlertCircle 
 } from 'lucide-react'
 import Link from 'next/link'
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
 
 export default async function QAPage() {
   // Only admins can access QA tools

--- a/app/(app)/qa/whoami/page.tsx
+++ b/app/(app)/qa/whoami/page.tsx
@@ -5,6 +5,7 @@ import { User, Shield, MapPin, Key, Clock } from 'lucide-react'
 import { requireAdmin } from '@/lib/admin/guards'
 import { getUserById, getUserRolesByLocation, getUserPermissionOverrides } from '@/lib/data/admin'
 import { createSupabaseServerClient } from '@/utils/supabase/server'
+export const runtime = 'nodejs';
 
 export default async function QAWhoAmIPage() {
   // Guard: require admin permissions

--- a/components/nav/SidebarClient.tsx
+++ b/components/nav/SidebarClient.tsx
@@ -19,7 +19,7 @@ import { can } from '@/lib/permissions'
 
 const navigation: { name: string; href: string; icon: any; permission: string | null }[] = [
   { name: 'Dashboard', href: '/', icon: Home, permission: null },
-  { name: 'Amministrazione', href: '/admin/users', icon: Users, permission: 'manage_users' },
+  { name: 'Amministrazione', href: '/admin/users', icon: Users, permission: 'users:manage' },
   { name: 'QA & Debug', href: '/qa', icon: Bug, permission: '*' },
   { name: 'Impostazioni', href: '/settings', icon: Settings, permission: 'view_settings' },
 ]

--- a/lib/admin/guards.ts
+++ b/lib/admin/guards.ts
@@ -1,35 +1,29 @@
-import { redirect } from 'next/navigation'
-import { createSupabaseServerClient } from '@/utils/supabase/server'
-import { canAny } from '@/lib/permissions/can'
+export const runtime = 'nodejs';
+
+import { redirect } from 'next/navigation';
+import { getEffectivePermissionsSSR } from '@/lib/permissions/server';
+import { normalizeSet, normalizePermission } from '@/lib/permissions';
 
 /**
  * Server-side admin guard - checks if user has admin permissions
  * Redirects to home page if not authorized
  */
-export async function requireAdmin(): Promise<string> {
+export async function requireAdmin(ctx?: { userId?: string; locationId?: string | null }): Promise<string> {
   try {
-    const supabase = await createSupabaseServerClient()
-    const { data: { user }, error: authError } = await supabase.auth.getUser()
-
-    if (authError || !user) {
-      redirect('/login')
+    const { userId: uid, permissions } = await getEffectivePermissionsSSR(ctx ?? {});
+    if (!uid) {
+      redirect('/login');
     }
+    const set = new Set(normalizeSet(permissions));
 
-    // Check if user has admin-level permissions
-    const hasAdminAccess = await canAny(user.id, [
-      'manage_users',
-      'assign_roles',
-      'admin.manage'
-    ])
+    if (set.has('*' as any)) return uid;
+    if (set.has(normalizePermission('users:manage') as any)) return uid;
+    if (set.has(normalizePermission('manage_users') as any)) return uid;
 
-    if (!hasAdminAccess) {
-      redirect('/?error=unauthorized')
-    }
-
-    return user.id
+    redirect('/?error=unauthorized');
   } catch (error) {
-    console.error('Error in admin guard:', error)
-    redirect('/?error=server_error')
+    console.error('Error in admin guard:', error);
+    redirect('/?error=server_error');
   }
 }
 
@@ -38,22 +32,15 @@ export async function requireAdmin(): Promise<string> {
  */
 export async function checkAdminAccess(): Promise<{ userId: string | null; hasAccess: boolean }> {
   try {
-    const supabase = await createSupabaseServerClient()
-    const { data: { user }, error: authError } = await supabase.auth.getUser()
-
-    if (authError || !user) {
-      return { userId: null, hasAccess: false }
-    }
-
-    const hasAdminAccess = await canAny(user.id, [
-      'manage_users',
-      'assign_roles', 
-      'admin.manage'
-    ])
-
-    return { userId: user.id, hasAccess: hasAdminAccess }
+    const { userId, permissions } = await getEffectivePermissionsSSR({});
+    const set = new Set(normalizeSet(permissions));
+    const hasAccess =
+      set.has('*' as any) ||
+      set.has(normalizePermission('users:manage') as any) ||
+      set.has(normalizePermission('manage_users') as any);
+    return { userId, hasAccess };
   } catch (error) {
-    console.error('Error checking admin access:', error)
-    return { userId: null, hasAccess: false }
+    console.error('Error checking admin access:', error);
+    return { userId: null, hasAccess: false };
   }
 }

--- a/lib/permissions/server.ts
+++ b/lib/permissions/server.ts
@@ -1,0 +1,96 @@
+import { createSupabaseServerClient } from '@/utils/supabase/server';
+import { createSupabaseAdminClient } from '@/lib/supabase/server';
+import { normalizeSet, normalizePermission } from '@/lib/permissions';
+
+export const runtime = 'nodejs';
+
+interface EffectivePermsOpts {
+  userId?: string;
+  locationId?: string | null;
+}
+
+export async function getEffectivePermissionsSSR({ userId, locationId = null }: EffectivePermsOpts) {
+  let resolvedUserId = userId;
+  if (!resolvedUserId) {
+    const supabase = await createSupabaseServerClient();
+    const { data: { user }, error } = await supabase.auth.getUser();
+    if (error || !user) return { userId: null, permissions: [] as string[] };
+    resolvedUserId = user.id;
+  }
+
+  const supabaseAdmin = createSupabaseAdminClient();
+
+  let assignmentsQuery = supabaseAdmin
+    .from('user_roles_locations')
+    .select('role_id, location_id')
+    .eq('user_id', resolvedUserId)
+    .eq('is_active', true);
+
+  if (locationId) {
+    assignmentsQuery = assignmentsQuery.in('location_id', [locationId, null]);
+  } else {
+    assignmentsQuery = assignmentsQuery.is('location_id', null);
+  }
+
+  const { data: assignments, error: assignErr } = await assignmentsQuery;
+  if (assignErr) return { userId: resolvedUserId, permissions: [] as string[] };
+
+  const roleIds = (assignments || []).map(a => a.role_id).filter(Boolean);
+  const permSet = new Set<string>();
+
+  if (roleIds.length > 0) {
+    const { data: rolePermissions } = await supabaseAdmin
+      .from('role_permissions')
+      .select('permission_id')
+      .in('role_id', roleIds);
+
+    if (rolePermissions && rolePermissions.length > 0) {
+      const permissionIds = rolePermissions.map(rp => rp.permission_id).filter(Boolean);
+      if (permissionIds.length > 0) {
+        const { data: permissions } = await supabaseAdmin
+          .from('permissions')
+          .select('name')
+          .in('id', permissionIds);
+
+        (permissions || []).forEach(p => {
+          if (p.name) permSet.add(p.name);
+        });
+      }
+    }
+  }
+
+  let overridesQuery = supabaseAdmin
+    .from('user_permissions')
+    .select('granted, location_id, permissions!inner(name)')
+    .eq('user_id', resolvedUserId);
+
+  if (locationId) {
+    overridesQuery = overridesQuery.in('location_id', [locationId, null]);
+  } else {
+    overridesQuery = overridesQuery.is('location_id', null);
+  }
+
+  const { data: overrides } = await overridesQuery;
+  (overrides || []).forEach(ov => {
+    const name = (ov.permissions as any)?.name as string | undefined;
+    if (!name) return;
+    if (ov.granted) permSet.add(name);
+    else permSet.delete(name);
+  });
+
+  const { data: isAdmin } = await supabaseAdmin.rpc('user_is_admin', { p_user: resolvedUserId });
+  if (isAdmin) permSet.add('*');
+
+  const permissions = normalizeSet(Array.from(permSet));
+  return { userId: resolvedUserId, permissions };
+}
+
+export async function canAnyServer(userId: string, keys: string[], locationId?: string | null) {
+  const { permissions } = await getEffectivePermissionsSSR({ userId, locationId });
+  const set = new Set(normalizeSet(permissions));
+  if (set.has('*' as any)) return true;
+  for (const k of keys) {
+    if (set.has(normalizePermission(k) as any)) return true;
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary
- align server-side requireAdmin with client logic, recognizing '*' and canonical `users:manage`
- add Node.js runtime declarations for admin and QA pages
- provide server-side permission utilities to fetch effective permissions and check wildcards

## Testing
- `npm run test:smoke` *(fails: tsx not found)*
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68bba8251734832aaabbc409350ea8e0