### PR TITLE
Use locations:edit permission for schedule tab

### DIFF
--- a/app/(app)/admin/locations/[id]/components/LocationScheduleTab.tsx
+++ b/app/(app)/admin/locations/[id]/components/LocationScheduleTab.tsx
@@ -39,7 +39,7 @@ export function LocationScheduleTab({ location }: Props) {
   const { permissions } = useAppStore()
 
   const isAdmin = can(permissions, '*')
-  const canEdit = isAdmin || can(permissions, 'locations:manage')
+  const canEdit = isAdmin || can(permissions, 'locations:edit')
 
   useEffect(() => {
     setOpeningHours(location.opening_hours || {})


### PR DESCRIPTION
## Summary
- replace the schedule tab guard to require the `locations:edit` permission instead of `locations:manage`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cab72423a0832aa2b4f256248cfe2e